### PR TITLE
フッターのデザインを変更

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -4,8 +4,8 @@ import { Box, Flex } from '@kuma-ui/core'
 
 export const Footer: FC = () => {
   return (
-    <footer className="bg-slate-100 w-screen absolute bottom-0">
-      <Flex justify="center" alignItems="center" height="7vh">
+    <footer className="bg-slate-100 w-screen fixed bottom-0">
+      <Flex justify="center" alignItems="center" height="5vh">
         <Box>
           <p>&copy; 2024 naokatu</p>
         </Box>


### PR DESCRIPTION
## 対応内容

- マイページのフッターが最下部に配置されていなかったため、fixedにして修正

## その他

- fixedにするとコンテンツが重なってしまうため、フッターをコンテンツの最下部に配置させるもっといい方法があるはず